### PR TITLE
[FEAT] Timestamped 생성

### DIFF
--- a/src/main/java/com/nexters/kekechebe/KekecheBeApplication.java
+++ b/src/main/java/com/nexters/kekechebe/KekecheBeApplication.java
@@ -2,7 +2,9 @@ package com.nexters.kekechebe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class KekecheBeApplication {
 

--- a/src/main/java/com/nexters/kekechebe/util/Timestamped.java
+++ b/src/main/java/com/nexters/kekechebe/util/Timestamped.java
@@ -1,0 +1,34 @@
+package com.nexters.kekechebe.util;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class Timestamped {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+    public static String dateTimeFormatter(LocalDateTime localDateTime) {
+        return localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    public static LocalDate getToday() {
+        return LocalDate.now();
+    }
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가 (#21)

### 반영 브랜치
feature/timestamped → develop

### 작업 사항
- 모든 테이블의 생성일(createdAt), 수정일(modifiedAt)을 공통으로 사용하기 위해 Timestamp를 구현
  - Spring Data JPA의 Audit 기능을 활용하여 엔티티가 생성되고, 변경되는 시점을 감지하고 시간을 기록
- dateTimeFormatter 추가
  - datetime을 필요에 따라 원하는 형식으로 변경 가능

ex) Entity 클래스에 extends 하여 사용
```java
public class Users extends Timestamped {...}
```

close #21