### PR TITLE
[FEAT] 하루 기준 기록 초과 작성 시 반려 처리

### DIFF
--- a/src/main/java/com/nexters/kekechebe/domain/memo/repository/MemoRepository.java
+++ b/src/main/java/com/nexters/kekechebe/domain/memo/repository/MemoRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface MemoRepository extends JpaRepository<Memo, Long> {
@@ -17,4 +18,6 @@ public interface MemoRepository extends JpaRepository<Memo, Long> {
     Page<Memo> findAllByMember(Member member, Pageable pageable);
 
     Page<Memo> findAllByMemberAndCharacter(Member member, Character character, Pageable pageable);
+
+    int countByMemberAndCharacterAndCreatedAtBetween(Member member, Character character, LocalDateTime startDateTime, LocalDateTime endDateTime);
 }

--- a/src/main/java/com/nexters/kekechebe/domain/memo/service/MemoService.java
+++ b/src/main/java/com/nexters/kekechebe/domain/memo/service/MemoService.java
@@ -9,6 +9,8 @@ import com.nexters.kekechebe.domain.memo.dto.request.MemoUpdateRequest;
 import com.nexters.kekechebe.domain.memo.dto.response.MemoPage;
 import com.nexters.kekechebe.domain.memo.entity.Memo;
 import com.nexters.kekechebe.domain.memo.repository.MemoRepository;
+import com.nexters.kekechebe.util.time.TimeUtil;
+import com.nexters.kekechebe.util.time.Today;
 import jakarta.persistence.NoResultException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -20,6 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MemoService {
+    private static final int MEMO_LIMIT = 3;
+
     private final MemoRepository memoRepository;
     private final MemberRepository memberRepository;
     private final CharacterRepository characterRepository;
@@ -33,6 +37,8 @@ public class MemoService {
                 .orElseThrow(() -> new NoResultException("회원을 찾을 수 없습니다."));
         Character character = characterRepository.findById(characterId)
                 .orElseThrow(() -> new NoResultException("캐릭터를 찾을 수 없습니다."));
+
+        validateMemoLimit(member, character);
 
         Memo memo = Memo.builder()
                 .content(content)
@@ -81,5 +87,15 @@ public class MemoService {
                 .orElseThrow(() -> new NoResultException("기록을 찾을 수 없습니다."));
 
         memoRepository.delete(memo);
+    }
+
+    private void validateMemoLimit(Member member, Character character) {
+        Today today = TimeUtil.getStartAndEndOfToday();
+
+        int memoCnt = memoRepository.countByMemberAndCharacterAndCreatedAtBetween(member, character, today.getStartOfDay(), today.getEndOfDay());
+
+        if (memoCnt >= MEMO_LIMIT) {
+            throw new IllegalStateException("캐릭터 당 허용된 기록 개수를 초과하였습니다.");
+        }
     }
 }

--- a/src/main/java/com/nexters/kekechebe/domain/memo/service/MemoService.java
+++ b/src/main/java/com/nexters/kekechebe/domain/memo/service/MemoService.java
@@ -95,7 +95,7 @@ public class MemoService {
         int memoCnt = memoRepository.countByMemberAndCharacterAndCreatedAtBetween(member, character, today.getStartOfDay(), today.getEndOfDay());
 
         if (memoCnt >= MEMO_LIMIT) {
-            throw new IllegalStateException("캐릭터 당 허용된 기록 개수를 초과하였습니다.");
+            throw new IllegalStateException("캐릭터당 허용된 기록 개수를 초과하였습니다.");
         }
     }
 }

--- a/src/main/java/com/nexters/kekechebe/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/nexters/kekechebe/exceptions/GlobalExceptionHandler.java
@@ -21,6 +21,11 @@ public class GlobalExceptionHandler {
         return ExceptionResponse.toResponseEntity(HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
+    @ExceptionHandler(value = {IllegalStateException.class})
+    protected ResponseEntity<ExceptionResponse> handleException(IllegalStateException e) {
+        return ExceptionResponse.toResponseEntity(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
     @ExceptionHandler(value = {MethodArgumentNotValidException.class})
     protected ResponseEntity<ExceptionResponse> handleException(MethodArgumentNotValidException e) {
         return ExceptionResponse.toResponseEntity(HttpStatus.BAD_REQUEST,

--- a/src/main/java/com/nexters/kekechebe/util/time/TimeUtil.java
+++ b/src/main/java/com/nexters/kekechebe/util/time/TimeUtil.java
@@ -1,0 +1,19 @@
+package com.nexters.kekechebe.util.time;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class TimeUtil {
+    public static Today getStartAndEndOfToday() {
+        LocalDate currentDate = LocalDate.now();
+
+        LocalDateTime startOfDay = LocalDateTime.of(currentDate, LocalTime.MIN);
+        LocalDateTime endOfDay = LocalDateTime.of(currentDate, LocalTime.MAX);
+
+        return Today.builder()
+                .startOfDay(startOfDay)
+                .endOfDay(endOfDay)
+                .build();
+    }
+}

--- a/src/main/java/com/nexters/kekechebe/util/time/Today.java
+++ b/src/main/java/com/nexters/kekechebe/util/time/Today.java
@@ -1,0 +1,15 @@
+package com.nexters.kekechebe.util.time;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class Today {
+    private final LocalDateTime startOfDay;
+    private final LocalDateTime endOfDay;
+}

--- a/src/test/java/com/nexters/kekechebe/TimeUtilTest.java
+++ b/src/test/java/com/nexters/kekechebe/TimeUtilTest.java
@@ -1,0 +1,39 @@
+package com.nexters.kekechebe;
+
+import com.nexters.kekechebe.util.time.TimeUtil;
+import com.nexters.kekechebe.util.time.Today;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TimeUtilTest {
+    @Test
+    public void 현재_날짜의_시작시간과_끝시간을_가져온다() {
+        // given
+        Today startAndEndOfToday = TimeUtil.getStartAndEndOfToday();
+
+        // when
+        LocalDateTime startOfDay = startAndEndOfToday.getStartOfDay();
+        LocalDateTime endOfDay = startAndEndOfToday.getEndOfDay();
+
+        // then
+        assertThat(startOfDay)
+                .hasYear(LocalDateTime.now().getYear())
+                .hasMonth(LocalDateTime.now().getMonth())
+                .hasDayOfMonth(LocalDateTime.now().getDayOfMonth())
+                .hasHour(0)
+                .hasMinute(0)
+                .hasSecond(0);
+
+        assertThat(endOfDay)
+                .hasYear(LocalDateTime.now().getYear())
+                .hasMonth(LocalDateTime.now().getMonth())
+                .hasDayOfMonth(LocalDateTime.now().getDayOfMonth())
+                .hasHour(23)
+                .hasMinute(59)
+                .hasSecond(59)
+                .hasNano(999999999);
+    }
+}


### PR DESCRIPTION
### PR 타입 (#17)

- [x] 기능 추가

### 반영 브랜치
feature/memo-limit → develop

### 작업 사항
- 하루의 시작(2024-01-24 00:00:00)과 끝(2024-01-24 23:59:59) 을 계산하는 TimeUtil 생성
- 계산한 시작 시간과 끝 시간으로 기록 개수 조회 구현
- 기록 개수 제한 (현재 3개)에 따라 반려 처리 구현

### 테스트 결과
Postman 테스트 결과 이상 없습니다.

### 코멘트
List에 넣어서 반환할까 생각했는데, 인덱스로 구분하는게 좋은 방법은 아닌 것 같아서 Today라는 DTO하나 만들어서 사용했습니다. 