### PR TITLE
[FEAT] 내 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/nexters/kekechebe/domain/character/repository/CharacterRepository.java
+++ b/src/main/java/com/nexters/kekechebe/domain/character/repository/CharacterRepository.java
@@ -1,7 +1,10 @@
 package com.nexters.kekechebe.domain.character.repository;
 
 import com.nexters.kekechebe.domain.character.entity.Character;
+import com.nexters.kekechebe.domain.member.entity.Member;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CharacterRepository extends JpaRepository<Character, Long> {
+    long countCharacterByMember(Member member);
 }

--- a/src/main/java/com/nexters/kekechebe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/nexters/kekechebe/domain/member/controller/MemberController.java
@@ -1,0 +1,30 @@
+package com.nexters.kekechebe.domain.member.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nexters.kekechebe.domain.member.service.MemberService;
+import com.nexters.kekechebe.dto.BaseResponse;
+import com.nexters.kekechebe.dto.DataResponse;
+import com.nexters.kekechebe.exceptions.StatusCode;
+import com.nexters.kekechebe.security.UserDetailsImpl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/member")
+public class MemberController {
+    private final MemberService memberService;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse> getMemberInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        long memberId = userDetails.getMember().getId();
+        return ResponseEntity.ok(new DataResponse<>(StatusCode.OK, memberService.getMemberInfo(memberId)));
+    }
+}

--- a/src/main/java/com/nexters/kekechebe/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/nexters/kekechebe/domain/member/dto/response/MemberResponse.java
@@ -1,0 +1,16 @@
+package com.nexters.kekechebe.domain.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
+public class MemberResponse {
+    private final long memberId;
+    private final long characterCount;
+    private final long memoCount;
+}

--- a/src/main/java/com/nexters/kekechebe/domain/member/service/MemberService.java
+++ b/src/main/java/com/nexters/kekechebe/domain/member/service/MemberService.java
@@ -1,0 +1,33 @@
+package com.nexters.kekechebe.domain.member.service;
+
+import org.springframework.stereotype.Service;
+
+import com.nexters.kekechebe.domain.character.repository.CharacterRepository;
+import com.nexters.kekechebe.domain.member.dto.response.MemberResponse;
+import com.nexters.kekechebe.domain.member.entity.Member;
+import com.nexters.kekechebe.domain.member.repository.MemberRepository;
+import com.nexters.kekechebe.domain.memo.repository.MemoRepository;
+
+import jakarta.persistence.NoResultException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+    private final CharacterRepository characterRepository;
+    private final MemoRepository memoRepository;
+
+    public MemberResponse getMemberInfo(long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new NoResultException("회원을 찾을 수 없습니다."));
+        long characterCount = characterRepository.countCharacterByMember(member);
+        long memoCount = memoRepository.countMemoByMember(member);
+
+        return MemberResponse.builder()
+            .memberId(member.getId())
+            .characterCount(characterCount)
+            .memoCount(memoCount)
+            .build();
+    }
+}

--- a/src/main/java/com/nexters/kekechebe/domain/memo/repository/MemoRepository.java
+++ b/src/main/java/com/nexters/kekechebe/domain/memo/repository/MemoRepository.java
@@ -20,4 +20,6 @@ public interface MemoRepository extends JpaRepository<Memo, Long> {
     Page<Memo> findAllByMemberAndCharacter(Member member, Character character, Pageable pageable);
 
     int countByMemberAndCharacterAndCreatedAtBetween(Member member, Character character, LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+    long countMemoByMember(Member member);
 }

--- a/src/main/java/com/nexters/kekechebe/jwt/JwtUtil.java
+++ b/src/main/java/com/nexters/kekechebe/jwt/JwtUtil.java
@@ -79,7 +79,7 @@ public class JwtUtil {
             log.info("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
             throw new CustomException(INVALID_JWT_SIGNATURE);
         } catch (ExpiredJwtException e) {
-            // log.info("Expired JWT token, 만료된 JWT token 입니다.");
+            log.info("Expired JWT token, 만료된 JWT token 입니다.");
             throw new CustomException(EXPIRED_JWT_TOKEN);
         } catch (UnsupportedJwtException e) {
             log.info("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가 (#10)

### 반영 브랜치
feature/mypage → develop

### 작업 사항
- 내 정보 조회 API 구현(해당 회원의 캐릭터 개수, 기록 개수 포함)
- 저번 [소셜 로그인 리뷰](https://github.com/Nexters/kekeche-be/pull/32#discussion_r1467206028)를 반영하여 Member와 Auth 도메인을 분리

### 테스트 결과
Postman 테스트 결과 이상 없습니다.

close #10 