### PR TITLE
[FIX] 소셜 로그인 버그 수정

### DIFF
--- a/src/main/java/com/nexters/kekechebe/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/kekechebe/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
             .authorizeHttpRequests((authorize) -> authorize
-                .requestMatchers("/api/v1/member/kakao/callback", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .requestMatchers("/api/v1/auth/kakao/callback", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/character/user/**").permitAll()
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/nexters/kekechebe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/nexters/kekechebe/domain/auth/controller/AuthController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nexters.kekechebe.domain.auth.service.AuthService;
 import com.nexters.kekechebe.domain.auth.dto.response.LoginResponse;
 import com.nexters.kekechebe.dto.BaseResponse;
@@ -15,7 +14,6 @@ import com.nexters.kekechebe.dto.DataResponse;
 import com.nexters.kekechebe.exceptions.StatusCode;
 import com.nexters.kekechebe.jwt.JwtUtil;
 
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,8 +26,8 @@ public class AuthController {
     private final AuthService authService;
 
     @GetMapping("/kakao/callback")
-    public ResponseEntity<BaseResponse> kakaoLogin(@RequestParam(value = "code") String code, HttpServletResponse response, HttpServletRequest request) throws
-        JsonProcessingException {
+    public ResponseEntity<BaseResponse> kakaoLogin(@RequestParam(value = "code") String code, HttpServletResponse response) {
+        log.info("Auth Controller >> code : {}", code);
 
         LoginResponse loginResponse = authService.kakaoLogin(code, response);
         String createToken = loginResponse.getAccessToken();

--- a/src/main/java/com/nexters/kekechebe/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/nexters/kekechebe/domain/auth/dto/response/TokenResponse.java
@@ -1,14 +1,13 @@
 package com.nexters.kekechebe.domain.auth.dto.response;
 
-import lombok.Builder;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@Builder
-@RequiredArgsConstructor
 @NoArgsConstructor(force = true)
 public class TokenResponse {
+    @JsonProperty("access_token")
     private final String accessToken;
 }

--- a/src/main/java/com/nexters/kekechebe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/nexters/kekechebe/domain/auth/service/AuthService.java
@@ -11,7 +11,6 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nexters.kekechebe.domain.auth.dto.response.TokenResponse;
 import com.nexters.kekechebe.domain.auth.dto.response.LoginResponse;
 import com.nexters.kekechebe.domain.auth.dto.response.UserInfoResponse;
@@ -35,7 +34,7 @@ public class AuthService {
     @Value("${oauth.kakao.redirect-uri}")
     private String redirectUri;
 
-    public LoginResponse kakaoLogin(String code, HttpServletResponse response) throws JsonProcessingException {
+    public LoginResponse kakaoLogin(String code, HttpServletResponse response) {
         String accessToken = getToken(code);
         UserInfoResponse userInfoDto = getKakaoUserInfo(accessToken);
         Member kakaoUser = registerKakaoUserIfNeeded(userInfoDto);
@@ -71,7 +70,7 @@ public class AuthService {
         TokenResponse tokenDto = response.getBody();
         assert tokenDto != null;
         String accessToken = tokenDto.getAccessToken();
-        log.info("access token : {}", accessToken);
+        log.info("Auth Service >> access token : {}", accessToken);
         return accessToken;
     }
 
@@ -95,7 +94,7 @@ public class AuthService {
         String nickname = userInfoDto.getNickname();
         String email = userInfoDto.getEmail();
 
-        log.info("user info : {}, {}, {}", id, nickname, email);
+        log.info("Auth Service >> user info : {}, {}, {}", id, nickname, email);
 
         return userInfoDto;
     }


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
feature/login → develop

### 작업 사항
- 카카오에서 token을 받아올 때, 카카오의 json key 값이 snake case여서 필드에 바인딩 되지 않는 이슈가 있었습니다.
- accessToken 필드에 JsonProperty 어노테이션을 추가하여 해결하였습니다.
- 그 외 작업 사항입니다.
  - SecurityConfig에 requestMatchers member → auth로 수정
  - AuthController, AuthService log 추가
  - JsonProcessingException 제거

### 테스트 결과
로컬 테스트 결과 이상 없습니다.