### PR TITLE
[FIX] 메모 저장 시 htmlContent도 저장하도록 변경

### DIFF
--- a/src/main/java/com/nexters/kekechebe/domain/memo/entity/Memo.java
+++ b/src/main/java/com/nexters/kekechebe/domain/memo/entity/Memo.java
@@ -52,10 +52,12 @@ public class Memo extends Timestamped {
     @Builder
     public Memo(
             String content,
+            String htmlContent,
             Member member,
             Character character
     ) {
         this.content = content;
+        this.htmlContent = htmlContent;
         this.member = member;
         this.character = character;
     }

--- a/src/main/java/com/nexters/kekechebe/domain/memo/service/MemoService.java
+++ b/src/main/java/com/nexters/kekechebe/domain/memo/service/MemoService.java
@@ -40,6 +40,7 @@ public class MemoService {
     public CharacterLevelUpResponse saveMemo(Member member, MemoCreateRequest request) {
         long characterId = request.getCharacterId();
         String content = request.getContent();
+        String htmlContent = request.getHtmlContent();
         List<String> hashtags = request.getHashtags();
 
         Character character = characterRepository.findById(characterId)
@@ -49,6 +50,7 @@ public class MemoService {
 
         Memo memo = Memo.builder()
                 .content(content)
+                .htmlContent(htmlContent)
                 .member(member)
                 .character(character)
                 .build();


### PR DESCRIPTION
### PR 타입
- [x] 기능 수정

### 반영 브랜치
fix/memo-html-content

### 작업 사항
- 메모 저장 시 html content도 저장하도록 수정

### 테스트 결과
Postman 테스트 결과 이상 없습니다.