### PR TITLE
[REFACTOR] 캐릭터 관련 로직 분리

### DIFF
--- a/src/main/java/com/nexters/kekechebe/domain/character/dto/response/CharacterLevelUpResponse.java
+++ b/src/main/java/com/nexters/kekechebe/domain/character/dto/response/CharacterLevelUpResponse.java
@@ -23,7 +23,7 @@ public class CharacterLevelUpResponse {
     private String itemImage;
     private List<Integer> keywords;
 
-    public static CharacterLevelUpResponse from(Character character, Integer level, boolean isLevelUp) {
+    public static CharacterLevelUpResponse from(Character character, boolean isLevelUp) {
         return CharacterLevelUpResponse.builder()
             .id(character.getId())
             .name(character.getName())

--- a/src/main/java/com/nexters/kekechebe/domain/character/dto/response/CharacterResponse.java
+++ b/src/main/java/com/nexters/kekechebe/domain/character/dto/response/CharacterResponse.java
@@ -6,6 +6,8 @@ import static com.nexters.kekechebe.util.UrlMaker.*;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.nexters.kekechebe.domain.character.entity.Character;
+import com.nexters.kekechebe.util.character.LevelUtil;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,8 +34,8 @@ public class CharacterResponse {
         this.name = character.getName();
         this.level = character.getLevel();
         this.totalExp = character.getExp();
-        this.currentExp = getCurrentExpThreshold(character.getExp());
-        this.nextExp = getNextExpThreshold(character.getExp());
+        this.currentExp = getLevelInfo(character.getExp()).getCurrentExpThreshold();
+        this.nextExp = getLevelInfo(character.getExp()).getNextExpThreshold();
         this.characterImage = madeCharacterUrl(character);
         this.itemImage = madeItemUrl(character);
         this.keywords = parseKeywords(character.getKeywords());
@@ -45,5 +47,9 @@ public class CharacterResponse {
         Type listType = new TypeToken<List<Integer>>() {}.getType();
 
         return gson.fromJson(keywords, listType);
+    }
+
+    private LevelUtil.LevelInfo getLevelInfo(Integer exp) {
+        return LevelUtil.getLevelInfo(exp);
     }
 }

--- a/src/main/java/com/nexters/kekechebe/domain/character/entity/Character.java
+++ b/src/main/java/com/nexters/kekechebe/domain/character/entity/Character.java
@@ -96,4 +96,8 @@ public class Character extends Timestamped {
     public Integer updateLevel(int count) {
         return this.level += count;
     }
+
+    public CharacterAsset.Variation updateVariation(CharacterAsset.Variation variation) {
+        return this.variation = variation;
+    }
 }

--- a/src/main/java/com/nexters/kekechebe/domain/character/enums/CharacterAsset.java
+++ b/src/main/java/com/nexters/kekechebe/domain/character/enums/CharacterAsset.java
@@ -36,12 +36,11 @@ public class CharacterAsset {
     @Getter
     @RequiredArgsConstructor
     public enum Variation {
-        VAR1(0, 1, 10),
-        VAR2(1, 11, 20),
-        VAR3(2, 21, 30);
+        VAR1(0, 1),
+        VAR2(1, 2),
+        VAR3(2, 3);
 
         private final Integer index;
-        private final Integer levelMin;
-        private final Integer levelMax;
+        private final Integer level;
     }
 }

--- a/src/main/java/com/nexters/kekechebe/domain/character/enums/Level.java
+++ b/src/main/java/com/nexters/kekechebe/domain/character/enums/Level.java
@@ -13,31 +13,4 @@ public enum Level {
     private final Integer level;
     private final Integer expMin;
     private final Integer expMax;
-
-    public static Integer getNextExpThreshold(int totalExp) {
-        for (Level level : values()) {
-            if (totalExp < level.getExpMax()) {
-                return level.getExpMax() - level.getExpMin();
-            }
-        }
-        return totalExp;
-    }
-
-    public static Integer getCurrentExpThreshold(int totalExp) {
-        for (Level level : values()) {
-            if (totalExp < level.getExpMax()) {
-                return totalExp - level.getExpMin();
-            }
-        }
-        return totalExp;
-    }
-
-    public static Integer getUpdatedLevel(int totalExp) {
-        for (Level level : values()) {
-            if (totalExp < level.getExpMax()) {
-                return level.getLevel();
-            }
-        }
-        return totalExp;
-    }
 }

--- a/src/main/java/com/nexters/kekechebe/domain/memo/service/CharacterHelperService.java
+++ b/src/main/java/com/nexters/kekechebe/domain/memo/service/CharacterHelperService.java
@@ -1,0 +1,35 @@
+package com.nexters.kekechebe.domain.memo.service;
+
+import static com.nexters.kekechebe.util.character.LevelUtil.*;
+
+import com.nexters.kekechebe.domain.character.entity.Character;
+import com.nexters.kekechebe.util.character.LevelUtil;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+class CharacterHelperService {
+    private static final int EXP_UP_COUNT = 1;
+    private static final int LEVEL_UP_COUNT = 1;
+
+    public void updateExp(Character character) {
+        character.updateExp(EXP_UP_COUNT);
+    }
+
+    public boolean isLevelUp(Character character) {
+        LevelUtil.LevelInfo levelInfo = LevelUtil.getLevelInfo(character.getExp());
+        if (character.getLevel() < levelInfo.getUpdatedLevel()) {
+            updateCharacter(character);
+            return true;
+        }
+        return false;
+    }
+
+    private void updateCharacter(Character character) {
+        Integer nextLevel = character.updateLevel(LEVEL_UP_COUNT);
+        character.updateVariation(getVariationByLevel(nextLevel));
+    }
+}

--- a/src/main/java/com/nexters/kekechebe/domain/memo/service/MemoService.java
+++ b/src/main/java/com/nexters/kekechebe/domain/memo/service/MemoService.java
@@ -1,7 +1,5 @@
 package com.nexters.kekechebe.domain.memo.service;
 
-import static com.nexters.kekechebe.util.character.LevelUtil.*;
-
 import com.nexters.kekechebe.domain.character.dto.response.CharacterLevelUpResponse;
 import com.nexters.kekechebe.domain.character.entity.Character;
 import com.nexters.kekechebe.domain.character.repository.CharacterRepository;
@@ -13,7 +11,6 @@ import com.nexters.kekechebe.domain.memo.dto.request.MemoUpdateRequest;
 import com.nexters.kekechebe.domain.memo.dto.response.MemoPage;
 import com.nexters.kekechebe.domain.memo.entity.Memo;
 import com.nexters.kekechebe.domain.memo.repository.MemoRepository;
-import com.nexters.kekechebe.util.character.LevelUtil;
 import com.nexters.kekechebe.util.time.TimeUtil;
 import com.nexters.kekechebe.util.time.Today;
 import jakarta.persistence.NoResultException;
@@ -30,9 +27,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MemoService {
     private static final int MEMO_LIMIT = 3;
-    private static final int EXP_UP_COUNT = 1;
-    private static final int LEVEL_UP_COUNT = 1;
 
+    private final CharacterHelperService characterHelperService;
     private final MemoRepository memoRepository;
     private final HashtagRepository hashtagRepository;
     private final CharacterRepository characterRepository;
@@ -57,14 +53,8 @@ public class MemoService {
                 .build();
         memoRepository.save(memo);
 
-        character.updateExp(EXP_UP_COUNT);
-
-        boolean isLevelUp = false;
-        if (checkLevelUp(character)) {
-            Integer nextLevel = character.updateLevel(LEVEL_UP_COUNT);
-            character.updateVariation(getVariationByLevel(nextLevel));
-            isLevelUp = true;
-        }
+        characterHelperService.updateExp(character);
+        boolean isLevelUp = characterHelperService.isLevelUp(character);
 
         List<Hashtag> buildHashTags = hashtags.stream()
                 .map(hashtag -> Hashtag.builder()
@@ -136,10 +126,5 @@ public class MemoService {
         if (memoCnt >= MEMO_LIMIT) {
             throw new IllegalStateException("캐릭터당 허용된 기록 개수를 초과하였습니다.");
         }
-    }
-
-    private boolean checkLevelUp(Character character) {
-        LevelUtil.LevelInfo getLevelInfo = LevelUtil.getLevelInfo(character.getExp());
-        return character.getLevel() < getLevelInfo.getUpdatedLevel();
     }
 }

--- a/src/main/java/com/nexters/kekechebe/domain/memo/service/MemoService.java
+++ b/src/main/java/com/nexters/kekechebe/domain/memo/service/MemoService.java
@@ -1,6 +1,6 @@
 package com.nexters.kekechebe.domain.memo.service;
 
-import static com.nexters.kekechebe.domain.character.enums.Level.*;
+import static com.nexters.kekechebe.util.character.LevelUtil.*;
 
 import com.nexters.kekechebe.domain.character.dto.response.CharacterLevelUpResponse;
 import com.nexters.kekechebe.domain.character.entity.Character;
@@ -13,6 +13,7 @@ import com.nexters.kekechebe.domain.memo.dto.request.MemoUpdateRequest;
 import com.nexters.kekechebe.domain.memo.dto.response.MemoPage;
 import com.nexters.kekechebe.domain.memo.entity.Memo;
 import com.nexters.kekechebe.domain.memo.repository.MemoRepository;
+import com.nexters.kekechebe.util.character.LevelUtil;
 import com.nexters.kekechebe.util.time.TimeUtil;
 import com.nexters.kekechebe.util.time.Today;
 import jakarta.persistence.NoResultException;
@@ -59,9 +60,9 @@ public class MemoService {
         character.updateExp(EXP_UP_COUNT);
 
         boolean isLevelUp = false;
-        Integer level = character.getLevel();
         if (checkLevelUp(character)) {
-            level = character.updateLevel(LEVEL_UP_COUNT);
+            Integer nextLevel = character.updateLevel(LEVEL_UP_COUNT);
+            character.updateVariation(getVariationByLevel(nextLevel));
             isLevelUp = true;
         }
 
@@ -73,7 +74,7 @@ public class MemoService {
                 .toList();
         hashtagRepository.saveAll(buildHashTags);
 
-        return CharacterLevelUpResponse.from(character, level, isLevelUp);
+        return CharacterLevelUpResponse.from(character, isLevelUp);
     }
 
     public MemoPage getAllMemos(Member member, Pageable pageable) {
@@ -138,6 +139,7 @@ public class MemoService {
     }
 
     private boolean checkLevelUp(Character character) {
-        return character.getLevel() < getUpdatedLevel(character.getExp());
+        LevelUtil.LevelInfo getLevelInfo = LevelUtil.getLevelInfo(character.getExp());
+        return character.getLevel() < getLevelInfo.getUpdatedLevel();
     }
 }

--- a/src/main/java/com/nexters/kekechebe/util/character/LevelUtil.java
+++ b/src/main/java/com/nexters/kekechebe/util/character/LevelUtil.java
@@ -6,7 +6,9 @@ import com.nexters.kekechebe.domain.character.enums.Level;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-public class LevelUtil {
+public final class LevelUtil {
+    private LevelUtil(){}
+
     public static LevelInfo getLevelInfo(int totalExp) {
         for (Level level : Level.values()) {
             if (totalExp < level.getExpMax()) {

--- a/src/main/java/com/nexters/kekechebe/util/character/LevelUtil.java
+++ b/src/main/java/com/nexters/kekechebe/util/character/LevelUtil.java
@@ -1,0 +1,40 @@
+package com.nexters.kekechebe.util.character;
+
+import com.nexters.kekechebe.domain.character.enums.CharacterAsset;
+import com.nexters.kekechebe.domain.character.enums.Level;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class LevelUtil {
+    public static LevelInfo getLevelInfo(int totalExp) {
+        for (Level level : Level.values()) {
+            if (totalExp < level.getExpMax()) {
+                int currentExpThreshold = totalExp - level.getExpMin();
+                int nextExpThreshold = level.getExpMax() - level.getExpMin();
+                return new LevelInfo(currentExpThreshold, nextExpThreshold, level.getLevel());
+            }
+        }
+        Level lastLevel = Level.values()[Level.values().length - 1];
+        int currentExpThreshold = totalExp - lastLevel.getExpMax();
+        int nextExpThreshold = 99; // 최대 레벨 99
+        return new LevelInfo(currentExpThreshold, nextExpThreshold, lastLevel.getLevel());
+    }
+
+    public static CharacterAsset.Variation getVariationByLevel(int level) {
+        for (CharacterAsset.Variation variation : CharacterAsset.Variation.values()) {
+            if (variation.getLevel().equals(level)) {
+                return variation;
+            }
+        }
+        return CharacterAsset.Variation.VAR3; // 3레벨 이상 VAR3
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class LevelInfo {
+        private final int currentExpThreshold;
+        private final int nextExpThreshold;
+        private final int updatedLevel;
+    }
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [x] 코드 리팩토링

### 반영 브랜치
refactor/character → develop

### 작업 사항
- Variation 기준을 levelMin, levelMax에서 간단히 level로 축소하였습니다.
- 캐릭터 레벨업 시, variation도 업데이트 되도록 변경 로직을 추가하였습니다.
- 기존 Level Enum에 존재하던 레벨업 관련 로직을 LevelUtil 클래스로 분리하였습니다.
- MemoService에서 캐릭터 경험치나 레벨을 업데이트 하는 로직을 CharacterHelperService로 분리하였습니다.
  - Entity 상태를 직접 수정하기 때문에 Util 클래스가 아닌 서비스 계층 클래스에 작성하였습니다.
  - CharacterHelperService는 default 접근 제한자를 가지기 때문에 해당 패키지내에서만 사용 가능합니다.
  - 클래스 분리 기준은 다음의 글을 참고하였습니다. ([Java Helper vs. Utility Classes](https://www.baeldung.com/java-helper-vs-utility-classes))

### 테스트 결과
Postman 테스트 결과 이상 없습니다.