### PR TITLE
[FIX] 카카오 로그인 시 트랜잭션 수정 및 CORS 도메인 추가

### DIFF
--- a/src/main/java/com/nexters/kekechebe/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/kekechebe/config/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig {
 
         configuration.addAllowedOrigin("http://localhost:3000");
         configuration.addAllowedOrigin("https://kekeche-deploy.vercel.app");
+        configuration.addAllowedOrigin("https://www.anotherme.today");
 
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");

--- a/src/main/java/com/nexters/kekechebe/domain/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/nexters/kekechebe/domain/auth/service/KakaoAuthService.java
@@ -7,14 +7,15 @@ import com.nexters.kekechebe.domain.auth.dto.response.UserInfoResponse;
 import com.nexters.kekechebe.domain.member.entity.Member;
 import com.nexters.kekechebe.domain.member.repository.MemberRepository;
 import com.nexters.kekechebe.jwt.JwtUtil;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class KakaoAuthService implements AuthService {
     private final MemberRepository memberRepository;
@@ -28,10 +29,12 @@ public class KakaoAuthService implements AuthService {
     private String characterRedirectUri;
 
     @Override
+    @Transactional
     public LoginResponse login(String code) {
         return kakaoLogin(code, redirectUri);
     }
 
+    @Transactional
     public LoginResponse characterLogin(String code) {
         return kakaoLogin(code, characterRedirectUri);
     }


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
fix/auth → develop

### 작업 사항
- 카카오 로그인 시 트랜잭션 적용
- CORS 설정 프론트 도메인 추가

### 테스트 결과
Postman 테스트 결과 이상 없습니다.