### PR TITLE
[REFACOTR] 이미지 확장자 변경 및 item 이미지 null 처리

### DIFF
--- a/src/main/java/com/nexters/kekechebe/domain/character/dto/response/CharacterLevelUpResponse.java
+++ b/src/main/java/com/nexters/kekechebe/domain/character/dto/response/CharacterLevelUpResponse.java
@@ -5,6 +5,7 @@ import static com.nexters.kekechebe.util.UrlMaker.*;
 import java.lang.reflect.Type;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.nexters.kekechebe.domain.character.entity.Character;
@@ -20,6 +21,7 @@ public class CharacterLevelUpResponse {
     private Integer level;
     private Boolean isLevelUp;
     private String characterImage;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String itemImage;
     private List<Integer> keywords;
 

--- a/src/main/java/com/nexters/kekechebe/domain/character/dto/response/CharacterResponse.java
+++ b/src/main/java/com/nexters/kekechebe/domain/character/dto/response/CharacterResponse.java
@@ -1,8 +1,8 @@
 package com.nexters.kekechebe.domain.character.dto.response;
 
-import static com.nexters.kekechebe.domain.character.enums.Level.*;
 import static com.nexters.kekechebe.util.UrlMaker.*;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.nexters.kekechebe.domain.character.entity.Character;
@@ -26,6 +26,7 @@ public class CharacterResponse {
     private Integer currentExp;
     private Integer nextExp;
     private String characterImage;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String itemImage;
     private List<Integer> keywords;
 

--- a/src/main/java/com/nexters/kekechebe/util/UrlMaker.java
+++ b/src/main/java/com/nexters/kekechebe/util/UrlMaker.java
@@ -19,7 +19,7 @@ public class UrlMaker {
     public static String madeItemUrl(Character character) {
         Integer itemValue = character.getItemIdx();
         if (itemValue == NO_ITEM) {
-            return "";
+            return null;
         }
         String prefix = "item";
         String item = String.valueOf(itemValue);

--- a/src/main/java/com/nexters/kekechebe/util/UrlMaker.java
+++ b/src/main/java/com/nexters/kekechebe/util/UrlMaker.java
@@ -12,7 +12,7 @@ public class UrlMaker {
         String shape = String.valueOf(character.getShapeIdx());
         String variation = character.getVariation().getIndex().toString();
         String color = String.valueOf(character.getColorIdx());
-        String png = ".png";
+        String png = ".webp";
         return String.format("%s/%s/%s/%s/%s%s", BASE_URL, prefix, shape, variation, color, png);
     }
 
@@ -23,7 +23,7 @@ public class UrlMaker {
         }
         String prefix = "item";
         String item = String.valueOf(itemValue);
-        String png = ".png";
+        String png = ".webp";
         return String.format("%s/%s/%s%s", BASE_URL, prefix, item, png);
     }
 }


### PR DESCRIPTION
### PR 타입
- [x] 코드 리팩토링

### 반영 브랜치
refactor/character-url → develop

### 작업 사항
- url 이미지 확장자를 png에서 webp로 변경하였습니다.
- itemImg가 null인 경우, response에서 해당 필드를 포함하지 않도록 하였습니다.

### 테스트 결과
Postman 테스트 결과 이상 없습니다.