### PR TITLE
[FEAT] 응원하기 기능 구현

### DIFF
--- a/src/main/java/com/nexters/kekechebe/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/kekechebe/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
             .authorizeHttpRequests((authorize) -> authorize
-                .requestMatchers("/api/v1/auth/kakao/callback", "/api/v1/auth/character-kakao/callback", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .requestMatchers("/api/v1/auth/kakao/callback", "/api/v1/auth/character-kakao/callback", "/swagger-ui/**", "/v3/api-docs/**", "/api/v1/member/cheer/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/character/member/**").permitAll()
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/nexters/kekechebe/domain/character/service/CharacterService.java
+++ b/src/main/java/com/nexters/kekechebe/domain/character/service/CharacterService.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static com.nexters.kekechebe.domain.character.enums.Level.LEVEL1;
-import static com.nexters.kekechebe.exceptions.StatusCode.TOKEN_UNAUTHORIZED;
+import static com.nexters.kekechebe.exceptions.StatusCode.UNAUTHORIZED_REQUEST;
 
 @Service
 @RequiredArgsConstructor
@@ -171,7 +171,7 @@ public class CharacterService {
 
     private void validateMember(Member member, Character character) {
         if (!member.getId().equals(character.getMember().getId())) {
-            throw new CustomException(TOKEN_UNAUTHORIZED);
+            throw new CustomException(UNAUTHORIZED_REQUEST);
         }
     }
 }

--- a/src/main/java/com/nexters/kekechebe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/nexters/kekechebe/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.nexters.kekechebe.domain.member.controller;
 
+import com.nexters.kekechebe.domain.member.dto.response.MemberCheerResponse;
 import com.nexters.kekechebe.domain.member.dto.response.MemberResponse;
 import com.nexters.kekechebe.domain.member.entity.Member;
 import com.nexters.kekechebe.domain.member.service.MemberService;
@@ -8,6 +9,7 @@ import com.nexters.kekechebe.exceptions.ExceptionResponse;
 import com.nexters.kekechebe.exceptions.StatusCode;
 import com.nexters.kekechebe.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -18,6 +20,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -44,5 +48,22 @@ public class MemberController {
     public ResponseEntity<DataResponse<MemberResponse>> getMemberInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         Member member = userDetails.getMember();
         return ResponseEntity.ok(new DataResponse<>(StatusCode.OK, memberService.getMemberInfo(member)));
+    }
+
+    @Operation(summary = "회원 응원하기", description = "회원을 응원합니다.")
+    @Parameter(name = "memberId", description = "응원할 회원의 id", example = "12", required = true)
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "BAD REQUEST",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ExceptionResponse.class))),
+        @ApiResponse(responseCode = "404", description = "NOT FOUND",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ExceptionResponse.class))),
+        @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ExceptionResponse.class))),
+    })
+    @PostMapping("/cheer/{memberId}")
+    public ResponseEntity<DataResponse<MemberCheerResponse>> updateCheerCount(
+        @PathVariable("memberId") Long memberId) {
+        return ResponseEntity.ok(new DataResponse<>(StatusCode.OK, memberService.updateCheerCount(memberId)));
     }
 }

--- a/src/main/java/com/nexters/kekechebe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/nexters/kekechebe/domain/member/controller/MemberController.java
@@ -63,7 +63,9 @@ public class MemberController {
     })
     @PostMapping("/cheer/{memberId}")
     public ResponseEntity<DataResponse<MemberCheerResponse>> updateCheerCount(
-        @PathVariable("memberId") Long memberId) {
-        return ResponseEntity.ok(new DataResponse<>(StatusCode.OK, memberService.updateCheerCount(memberId)));
+        @PathVariable("memberId") Long memberId
+        , @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        Member loginMember = userDetails != null ? userDetails.getMember() : null;
+        return ResponseEntity.ok(new DataResponse<>(StatusCode.OK, memberService.updateCheerCount(loginMember, memberId)));
     }
 }

--- a/src/main/java/com/nexters/kekechebe/domain/member/dto/response/MemberCheerResponse.java
+++ b/src/main/java/com/nexters/kekechebe/domain/member/dto/response/MemberCheerResponse.java
@@ -1,0 +1,15 @@
+package com.nexters.kekechebe.domain.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
+public class MemberCheerResponse {
+    private final Long memberId;
+    private final Integer cheerCount;
+}

--- a/src/main/java/com/nexters/kekechebe/domain/member/entity/Member.java
+++ b/src/main/java/com/nexters/kekechebe/domain/member/entity/Member.java
@@ -34,6 +34,9 @@ public class Member extends Timestamped {
     @Column(name = "kakao_id", nullable = false)
     private Long kakaoId;
 
+    @Column(name = "cheer_count", nullable = false)
+    private Integer cheerCount;
+
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Character> characters = new ArrayList<>();
 
@@ -44,10 +47,16 @@ public class Member extends Timestamped {
     public Member(
             String email,
             String nickname,
-            Long kakaoId
+            Long kakaoId,
+            Integer cheerCount
     ) {
         this.email = email;
         this.nickname = nickname;
         this.kakaoId = kakaoId;
+        this.cheerCount = cheerCount;
+    }
+
+    public Integer updateCheerCount(int count) {
+        return this.cheerCount += count;
     }
 }

--- a/src/main/java/com/nexters/kekechebe/domain/member/service/MemberService.java
+++ b/src/main/java/com/nexters/kekechebe/domain/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.nexters.kekechebe.domain.member.service;
 
+import static com.nexters.kekechebe.exceptions.StatusCode.*;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,6 +11,7 @@ import com.nexters.kekechebe.domain.member.dto.response.MemberResponse;
 import com.nexters.kekechebe.domain.member.entity.Member;
 import com.nexters.kekechebe.domain.member.repository.MemberRepository;
 import com.nexters.kekechebe.domain.memo.repository.MemoRepository;
+import com.nexters.kekechebe.exceptions.CustomException;
 
 import jakarta.persistence.NoResultException;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +37,10 @@ public class MemberService {
     }
 
     @Transactional
-    public MemberCheerResponse updateCheerCount(Long accessMemberId) {
+    public MemberCheerResponse updateCheerCount(Member loginMember, Long accessMemberId) {
+        if (loginMember != null && accessMemberId.equals(loginMember.getId())) {
+            throw new CustomException(UNAUTHORIZED_REQUEST);
+        }
         Member accessMember = memberRepository.findById(accessMemberId)
             .orElseThrow(() -> new NoResultException("회원을 찾을 수 없습니다."));
         Integer nextCount = accessMember.updateCheerCount(1);

--- a/src/main/java/com/nexters/kekechebe/domain/member/service/MemberService.java
+++ b/src/main/java/com/nexters/kekechebe/domain/member/service/MemberService.java
@@ -4,10 +4,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nexters.kekechebe.domain.character.repository.CharacterRepository;
+import com.nexters.kekechebe.domain.member.dto.response.MemberCheerResponse;
 import com.nexters.kekechebe.domain.member.dto.response.MemberResponse;
 import com.nexters.kekechebe.domain.member.entity.Member;
+import com.nexters.kekechebe.domain.member.repository.MemberRepository;
 import com.nexters.kekechebe.domain.memo.repository.MemoRepository;
 
+import jakarta.persistence.NoResultException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -16,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
     private final CharacterRepository characterRepository;
     private final MemoRepository memoRepository;
+    private final MemberRepository memberRepository;
 
     public MemberResponse getMemberInfo(Member member) {
         long characterCount = characterRepository.countCharacterByMember(member);
@@ -26,6 +30,17 @@ public class MemberService {
             .nickname(member.getNickname())
             .characterCount(characterCount)
             .memoCount(memoCount)
+            .build();
+    }
+
+    @Transactional
+    public MemberCheerResponse updateCheerCount(Long accessMemberId) {
+        Member accessMember = memberRepository.findById(accessMemberId)
+            .orElseThrow(() -> new NoResultException("회원을 찾을 수 없습니다."));
+        Integer nextCount = accessMember.updateCheerCount(1);
+        return MemberCheerResponse.builder()
+            .memberId(accessMember.getId())
+            .cheerCount(nextCount)
             .build();
     }
 }

--- a/src/main/java/com/nexters/kekechebe/exceptions/StatusCode.java
+++ b/src/main/java/com/nexters/kekechebe/exceptions/StatusCode.java
@@ -20,11 +20,11 @@ public enum StatusCode {
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
     UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "지원되지 않는 JWT 토큰 입니다."),
     JWT_CLAIMS_IS_EMPTY(HttpStatus.UNAUTHORIZED, "잘못된 JWT 토큰 입니다."),
-    TOKEN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한 정보가 잘못된 토큰입니다."),
 
     /**
      * 403 FORBIDDEN
      */
+    UNAUTHORIZED_REQUEST(HttpStatus.FORBIDDEN, "권한이 없는 요청입니다."),
 
     /**
      * 404 NOT FOUND


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feature/cheer → develop

### 작업 사항
- 회원 응원하기 기능을 구현하였습니다.
  - Entity를 분리할까 고민하였지만 현재 로그인하지 않는 유저도 응원하기를 할 수 있는 등 여러가지를 고려하여 분리하지 않기로 결정했습니다.
- 본인 페이지일 경우, 응원하기 기능을 제한하였습니다.
- 권한 없는 요청의 statusCode를 401 UNAUTHORIZED 에서 403 FORBIDDEN 으로 변경하였습니다.

### 테스트 결과
Postman 테스트 결과 이상 없습니다.